### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -61,7 +61,7 @@ function logToRenderer(level: string, ...args: any[]) {
   writeLog(`[${level}] ${message}`);
   if (mainWindow?.webContents) {
     mainWindow.webContents.executeJavaScript(
-      `console.${level.toLowerCase()}('${message.replace(/'/g, "\\'")}')`
+      `console.${level.toLowerCase()}('${escapeJsString(message)}')`
     ).catch(() => {});
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Dboire9/POE2_HTC/security/code-scanning/2](https://github.com/Dboire9/POE2_HTC/security/code-scanning/2)

To correctly escape strings intended for inclusion in JavaScript string literals, both single quotes and backslashes must be escaped. That is, all `'` characters should become `\'` and all `\` become `\\`.  
The recommended practice is to use a well-tested library (such as `js-string-escape`) to perform the escaping. As we cannot assume new dependencies unless essential, but `js-string-escape` is tiny and well-maintained, we can import and use it for clarity and correctness.  

**In general terms:**  
- Replace the manual `.replace(/'/g, "\\'")` logic with a robust escaping function that escapes both backslashes and quotes.
- Ideally, use a well-tested library like `js-string-escape`. Alternatively, explicitly call `.replace(/\\/g, '\\\\').replace(/'/g, "\\'")` for correct coverage.

**Where to change:**  
- In file `electron/main.ts`, update line 64 (the argument to `executeJavaScript`) to use the improved escaping.
- Add an import of `js-string-escape` at the top if possible (or implement a local escape function if new dependencies are forbidden).

**What is needed:**  
- Import and use of `js-string-escape`, or otherwise a correct inline implementation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
